### PR TITLE
Stop scaling text relative viewport for large screens.

### DIFF
--- a/source/stylesheets/_layout.sass
+++ b/source/stylesheets/_layout.sass
@@ -196,8 +196,6 @@ nav
   margin-left: auto
   margin-right: auto
   width: 90%
-  @media (min-width: 960px)
-    font-size: 1.7vw // Scale text with the viewport width
 
 // Columns
 // -------

--- a/source/stylesheets/_layout.sass
+++ b/source/stylesheets/_layout.sass
@@ -196,6 +196,8 @@ nav
   margin-left: auto
   margin-right: auto
   width: 90%
+  @media (min-width: 1400px)
+    font-size: 1.4em // Fixed size font for larger screens
 
 // Columns
 // -------


### PR DESCRIPTION
Cool site dude! Super helpful.

The scale of the text on large monitors (mine's 27") is pretty hard to read and because the font-size scales relative to the viewport width, zooming out using the browser controls has no effect.
 
I have included some screenshots of how the fonts render before and after the change.

https://imgur.com/a/37ZT9h8