### PR TITLE
Don't serve 404 at /journal

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[[redirects]]
+  from = "/journal"
+  to = "/"


### PR DESCRIPTION
We don't have anything really valuable to serve there, and realistically
we should serve everything without /journal, but for now this will do.

See https://docs.netlify.com/configure-builds/file-based-configuration/
for details of the syntax of the config file.